### PR TITLE
Change branch_names type to tuple

### DIFF
--- a/torchreid/components/branches.py
+++ b/torchreid/components/branches.py
@@ -26,7 +26,7 @@ class MultiBranchNetwork(nn.Module):
 
     def _get_branches(self, backbone, args) -> list:
 
-        branch_names = frozenset(args['branches'])
+        branch_names = tuple(args['branches'])
         branch_list = []
 
         for branch_name in branch_names:


### PR DESCRIPTION
According to Python documentation, 'sets do not record element position or order of insertion' and the ordering of the elements is not deterministic, i.e. might change with the random seed or other seemingly irrelevant operations (in my case it changed with changing the test batch size). If the order of branches changes, attempting to load a model will result in layer name mismatch, and hence the layers being incorrectly populated with random weights, preventing the reproducibility of results in testing. Changing the type of branch_names to tuple ensures the object is still immutable and has deterministic behaviour.